### PR TITLE
DEV: Fix an `ActiveModel::Errors` deprecation

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -26,7 +26,7 @@ after_initialize do
         .first
 
       if last_post_user_id == record.user_id
-        record.errors[:base] << I18n.t("no_bump_error")
+        record.errors.add(:base, message: I18n.t("no_bump_error"))
       end
     end
   end

--- a/spec/components/no_bump_validator_spec.rb
+++ b/spec/components/no_bump_validator_spec.rb
@@ -22,6 +22,7 @@ describe NoBumpValidator do
         expect(post).to be_present
         reply = Fabricate.build(:post, topic: post.topic, user: user)
         expect(reply).not_to be_valid
+        expect(reply.errors.first.message).to eq("Please wait for other users to participate before replying")
       end
 
       it "honors a post skips_validation flag" do


### PR DESCRIPTION
The warning was:

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from validate at discourse/plugins/discourse-no-bump/plugin.rb:29)
```