### PR TITLE
FIX: Remove bump on revision logic

### DIFF
--- a/lib/discourse_no_bump/no_bump_validator.rb
+++ b/lib/discourse_no_bump/no_bump_validator.rb
@@ -2,6 +2,10 @@
 
 module DiscourseNoBump
   class NoBumpValidator < ActiveModel::Validator
+    # When creating a post, validates that a user cannot bump their own topic
+    # unless they are staff or above a certain trust level.
+    #
+    # Post revisions are irrelevant, because they don't bump topics in core.
     def validate(record)
       return unless SiteSetting.no_bump_enabled?
       return if record.topic.private_message?

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,9 +13,5 @@ after_initialize do
   require_relative "lib/discourse_no_bump/no_bump_validator"
   require_relative "lib/discourse_no_bump/post_extension"
 
-  add_to_class :post_revisor, :bypass_bump? do
-    !@editor.staff?
-  end
-
   reloadable_patch { Post.prepend(DiscourseNoBump::PostExtension) }
 end

--- a/spec/components/no_bump_validator_spec.rb
+++ b/spec/components/no_bump_validator_spec.rb
@@ -84,14 +84,14 @@ RSpec.describe DiscourseNoBump::NoBumpValidator do
         expect(topic.bumped_at.to_i).to eq(bumped_at.to_i)
       end
 
-      it "will bump when staff revises" do
+      it "doesn't bump when staff revises" do
         PostRevisor.new(post).revise!(
           Fabricate(:admin),
           { raw: "this is different text for the body" },
           force_new_version: true,
         )
         topic.reload
-        expect(topic.bumped_at.to_i).not_to eq(bumped_at.to_i)
+        expect(topic.bumped_at.to_i).to eq(bumped_at.to_i)
       end
     end
   end
@@ -103,16 +103,6 @@ RSpec.describe DiscourseNoBump::NoBumpValidator do
       expect(post).to be_present
       reply = Fabricate.build(:post, topic: post.topic, user: user)
       expect(reply).to be_valid
-    end
-
-    it "will bump on revision" do
-      PostRevisor.new(post).revise!(
-        user,
-        { raw: "this is different text for the body" },
-        force_new_version: true,
-      )
-      topic.reload
-      expect(topic.bumped_at.to_i).not_to eq(bumped_at.to_i)
     end
   end
 end


### PR DESCRIPTION
Recently in discourse/discourse@2a65bf452224ece92981a9a26579ece67f10855b
and discourse/discourse@f0e0b024941660676744e38490313277ecc7e2fa we
made it so editing posts no longer bumps topics, except in very specific
conditions.

This comit removes the logic in this plugin that was trying to
bypass bumping on revisions if the user is not staff, which is
unnecessary now because core doesn't let anyone bump on edits.
